### PR TITLE
Removendo o método getByID das interfaces IService e IController.

### DIFF
--- a/src/main/java/com/jogamais/ufcg/controllers/IController.java
+++ b/src/main/java/com/jogamais/ufcg/controllers/IController.java
@@ -7,9 +7,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/default")
 public interface IController {
 
-    @RequestMapping(value = "/{id}", method = RequestMethod.GET)
-    ResponseEntity<?> getById(@PathVariable Long id);
-
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
     ResponseEntity<?> deleteById(@PathVariable Long id);
 

--- a/src/main/java/com/jogamais/ufcg/services/IService.java
+++ b/src/main/java/com/jogamais/ufcg/services/IService.java
@@ -6,8 +6,6 @@ import org.springframework.data.domain.PageRequest;
 
 public interface IService<T> {
 
-    public abstract Object getById(Long id) throws UserException;
-
     public abstract T create(T entity) throws UserException;
 
     public abstract void deleteById(Long id) throws UserException;

--- a/src/main/java/com/jogamais/ufcg/services/UserService.java
+++ b/src/main/java/com/jogamais/ufcg/services/UserService.java
@@ -17,7 +17,6 @@ public class UserService implements IService<User>{
     @Autowired
     private UserRepository userRepository;
 
-    @Override
     public User getById(Long id) throws UserException {
         return userRepository.findById(id).orElseThrow(UserException::new);
     }


### PR DESCRIPTION
Necessário a remoção do método pois ele não é usado em `Appointment`, o que estava gerando erro pois era obrigatório implementá-lo.